### PR TITLE
Use performance now in tokenizeString instead of the raw Date.now()

### DIFF
--- a/lib/src/vscode-textmate/index.js
+++ b/lib/src/vscode-textmate/index.js
@@ -1427,9 +1427,9 @@ function ne(e, t, s, r, i, o, a, c) {
     })(e, t, s, r, i, o);
     (i = a.stack), (r = a.linePos), (s = a.isFirstLine), (u = a.anchorPosition);
   }
-  const p = Date.now();
+  const p = _();
   for (; !h; ) {
-    if (0 !== c && Date.now() - p > c) return new te(i, !0);
+    if (0 !== c && _() - p > c) return new te(i, !0);
     d();
   }
   return new te(i, !1);


### PR DESCRIPTION
This function is being exported and used downstream in some projects that rely on next.js 16's cache components.

This doesn't allow using Date.now() and requires the use of performance.now() instead.

Since this file already imports the helper for using performanceNow() let's move over to use that.

This closes https://github.com/code-hike/lighter/issues/51.

Also, I've upstreamed this request: https://github.com/microsoft/vscode-textmate/pull/258